### PR TITLE
18 yaml parser for model mapping

### DIFF
--- a/flexcv/model_mapping.yaml
+++ b/flexcv/model_mapping.yaml
@@ -1,0 +1,52 @@
+LinearModel:
+    requires_inner_cv: False
+    n_trials: 100
+    n_jobs_model: 1
+    n_jobs_cv: 1
+    model: flexcv.models.LinearModel
+    params: {}
+    post_processor: flexcv.model_postprocessing.LinearModelPostProcessor
+
+RandomForest:
+  requires_inner_cv: true
+  n_trials: 400
+  n_jobs_model: 1
+  n_jobs_cv: -1
+  model: sklearn.ensemble.RandomForestRegressor
+  params:
+    max_depth: !Int
+      low: 5
+      high: 100
+    min_samples_split: !Int
+      low: 2
+      high: 1000
+      log: true
+    min_samples_leaf: !Int
+      low: 2
+      high: 5000
+      log: true
+    max_samples: !Float
+      low: 0.0021
+      high: 0.9
+    max_features: !Int
+      low: 1
+      high: 10
+    max_leaf_nodes: !Int
+      low: 10
+      high: 40000
+    min_impurity_decrease: !Float
+      low: 0.0000000008
+      high: 0.02
+      _kwargs:
+        log: true
+    min_weight_fraction_leaf: !Float
+      low: 0, 
+      high: 0.5
+    ccp_alpha: !Float
+      low: 1e-08
+      high: 0.01
+    n_estimators: !Int
+      low: 2
+      high: 7000
+  post_processor: flexcv.model_postprocessing.RandomForestModelPostProcessor
+  add_merf: true

--- a/flexcv/yaml_parser.py
+++ b/flexcv/yaml_parser.py
@@ -78,6 +78,11 @@ def parse_yaml_output_to_mapping_dict(yaml_dict) -> ModelMappingDict:
     """This function parses the output of the yaml parser to a ModelMappingDict object.
     Models and post processors are imported automatically.
     
+    Note:
+        Despite of automatically importing the classes, no arbitrary code is executed.
+        The yaml parser uses the safe loader and a custom constructors for the optuna distributions.
+        The imports are done by the importlib module.
+    
     Args:
         yaml_dict (dict): The output of the yaml parser.
         
@@ -110,6 +115,11 @@ def read_mapping_from_yaml_file(yaml_file_path: str) -> ModelMappingDict:
     """This function reads in a yaml file and returns a ModelMappingDict object.
     Use the yaml tags !Int, !Float, !Cat to specify the type of the hyperparameter distributions.
     The parser takes care of importing the classes specified in the yaml file in the fields model and post_processor.
+    
+    Note:
+        Despite of automatically importing the classes, no arbitrary code is executed.
+        The yaml parser uses the safe loader and a custom constructors for the optuna distributions.
+        The imports are done by the importlib module.
     
     Args:
         yaml_code (str): The yaml code.
@@ -144,6 +154,11 @@ def read_mapping_from_yaml_string(yaml_code: str) -> ModelMappingDict:
     """This function reads a yaml string and returns a ModelMappingDict object.
     Use the yaml tags !Int, !Float, !Cat to specify the type of the hyperparameter distributions.
     The parser takes care of importing the classes specified in the yaml file in the fields model and post_processor.
+    
+    Note:
+        Despite of automatically importing the classes, no arbitrary code is executed.
+        The yaml parser uses the safe loader and a custom constructors for the optuna distributions.
+        The imports are done by the importlib module.
     
     Args:
         yaml_code (str): The yaml code.

--- a/flexcv/yaml_parser.py
+++ b/flexcv/yaml_parser.py
@@ -1,0 +1,91 @@
+import yaml
+import importlib
+from optuna.distributions import IntDistribution, FloatDistribution, CategoricalDistribution
+from flexcv.model_mapping import ModelConfigDict, ModelMappingDict
+
+
+def int_constructor(loader: yaml.SafeLoader, node: yaml.nodes.ScalarNode) -> IntDistribution:
+    """Construct an IntDistribution."""
+    return IntDistribution(**loader.construct_mapping(node))
+
+
+def float_constructor(loader: yaml.SafeLoader, node: yaml.nodes.ScalarNode) -> FloatDistribution:
+    """Construct an FloatDistribution."""
+    return FloatDistribution(**loader.construct_mapping(node))
+
+
+def cat_constructor(loader: yaml.SafeLoader, node: yaml.nodes.ScalarNode) -> CategoricalDistribution:
+    """Construct an FloatDistribution."""
+    value = loader.construct_mapping(node, deep=True)
+    return CategoricalDistribution(**value)
+    
+    
+def get_loader():
+    loader = yaml.SafeLoader
+    loader.add_constructor("!Int", int_constructor)
+    loader.add_constructor("!Float", float_constructor)
+    loader.add_constructor("!Cat", cat_constructor)
+    return loader
+
+
+def split_import(import_string) -> tuple[str, str]:
+    import_list = import_string.split(".")
+    class_name = import_list[-1]
+    module_path = ".".join(import_list[:-1])
+    return class_name, module_path
+
+
+def parse_yaml_output_to_mapping_dict(yaml_dict):
+    model_mapping_dict = ModelMappingDict()
+    for model_name, raw_dict in yaml_dict.items():
+        if "model" not in raw_dict:
+            raise ValueError(f"model name is missing for model {model_name}")
+        
+        imports_dict = {}
+        import_list = ["model"]
+        if "post_processor" in raw_dict:
+            import_list.append("post_processor")
+        
+        for key in import_list:
+            class_name, path = split_import(raw_dict[key])
+            foo = importlib.import_module(path)
+            imports_dict[key] = getattr(foo, class_name)
+
+        # replace the strings in raw_dict with the imported classes
+        raw_dict.update(imports_dict)
+        model_config_dict = ModelConfigDict(raw_dict)
+        model_mapping_dict[model_name] = model_config_dict
+    return model_mapping_dict
+
+
+def read_mapping_from_yaml_file(yaml_file_path):
+    with open(yaml_file_path, "r") as f:
+        yaml_output = yaml.load(f, Loader=get_loader())
+    model_mapping = parse_yaml_output_to_mapping_dict(yaml_output)
+    return model_mapping
+
+
+def read_mapping_from_yaml_string(yaml_code):
+    yaml_output = yaml.load(yaml_code, Loader=get_loader())
+    model_mapping = parse_yaml_output_to_mapping_dict(yaml_output)
+    return model_mapping
+
+
+if __name__ == "__main__":
+
+    yaml_code = """
+    LinearModel:
+        model: flexcv.models.LinearModel
+        post_processor: flexcv.model_postprocessing.LinearModelPostProcessor
+        params:
+            max_depth: !Int
+                low: 5
+                high: 100
+                log: true
+            min_impurity_decrease: !Float
+                low: 0.00000001
+                high: 0.02
+            features: !Cat 
+                choices: [a, b, c]
+    """
+    print(read_mapping_from_yaml_string(yaml_code))

--- a/flexcv/yaml_parser.py
+++ b/flexcv/yaml_parser.py
@@ -5,22 +5,53 @@ from flexcv.model_mapping import ModelConfigDict, ModelMappingDict
 
 
 def int_constructor(loader: yaml.SafeLoader, node: yaml.nodes.ScalarNode) -> IntDistribution:
-    """Construct an IntDistribution."""
+    """Construct an optuna IntDistribution from a yaml node.
+    
+    Args:
+        loader (yaml.SafeLoader): The yaml loader.
+        node (yaml.nodes.ScalarNode): The yaml node.
+    
+    Returns:
+        (IntDistribution): The constructed IntDistribution.
+    """
     return IntDistribution(**loader.construct_mapping(node))
 
 
 def float_constructor(loader: yaml.SafeLoader, node: yaml.nodes.ScalarNode) -> FloatDistribution:
-    """Construct an FloatDistribution."""
+    """Construct an optuna FloatDistribution from a yaml node.
+    
+    Args:
+        loader (yaml.SafeLoader): The yaml loader.
+        node (yaml.nodes.ScalarNode): The yaml node.
+        
+    Returns:
+        (FloatDistribution): The constructed FloatDistribution.
+    """
     return FloatDistribution(**loader.construct_mapping(node))
 
 
 def cat_constructor(loader: yaml.SafeLoader, node: yaml.nodes.ScalarNode) -> CategoricalDistribution:
-    """Construct an FloatDistribution."""
+    """Construct an optuna CategoricalDistribution from a yaml node.
+    
+    Args:
+        loader (yaml.SafeLoader): The yaml loader.
+        node (yaml.nodes.ScalarNode): The yaml node.
+        
+    Returns:
+        (CategoricalDistribution): The constructed CategoricalDistribution.
+    """
     value = loader.construct_mapping(node, deep=True)
     return CategoricalDistribution(**value)
     
     
 def get_loader():
+    """This function returns a yaml loader with the custom constructors for the optuna distributions.
+    Custom and safe constructors are added to the following tags: 
+    
+    - !Int
+    - !Float 
+    - !Cat
+    """
     loader = yaml.SafeLoader
     loader.add_constructor("!Int", int_constructor)
     loader.add_constructor("!Float", float_constructor)
@@ -29,13 +60,30 @@ def get_loader():
 
 
 def split_import(import_string) -> tuple[str, str]:
+    """This function splits an import string into the class name and the module path.
+    
+    Args: 
+        import_string (str): The import string.
+    
+    Returns:
+        (tuple[str, str]): The class name and the module path.    
+    """
     import_list = import_string.split(".")
     class_name = import_list[-1]
     module_path = ".".join(import_list[:-1])
     return class_name, module_path
 
 
-def parse_yaml_output_to_mapping_dict(yaml_dict):
+def parse_yaml_output_to_mapping_dict(yaml_dict) -> ModelMappingDict:
+    """This function parses the output of the yaml parser to a ModelMappingDict object.
+    Models and post processors are imported automatically.
+    
+    Args:
+        yaml_dict (dict): The output of the yaml parser.
+        
+    Returns:
+        (ModelMappingDict): A dictionary of ModelConfigDict objects.
+    """
     model_mapping_dict = ModelMappingDict()
     for model_name, raw_dict in yaml_dict.items():
         if "model" not in raw_dict:
@@ -58,14 +106,68 @@ def parse_yaml_output_to_mapping_dict(yaml_dict):
     return model_mapping_dict
 
 
-def read_mapping_from_yaml_file(yaml_file_path):
+def read_mapping_from_yaml_file(yaml_file_path: str) -> ModelMappingDict:
+    """This function reads in a yaml file and returns a ModelMappingDict object.
+    Use the yaml tags !Int, !Float, !Cat to specify the type of the hyperparameter distributions.
+    The parser takes care of importing the classes specified in the yaml file in the fields model and post_processor.
+    
+    Args:
+        yaml_code (str): The yaml code.
+        
+    Returns:
+        (ModelMappingDict): A dictionary of ModelConfigDict objects.
+    
+    Example:
+        Your file.yaml file could look like this:
+        ```yaml
+        RandomForest:
+            model: sklearn.ensemble.RandomForestRegressor
+            post_processor: flexcv.model_postprocessing.MixedEffectsPostProcessor
+            requires_inner_cv: True
+            params:
+                max_depth: !Int
+                    low: 1
+                    high: 10
+        ```
+        And you would read it in like this:
+        ```python
+        model_mapping = read_mapping_from_yaml_file("file.yaml")
+        ```
+    """
     with open(yaml_file_path, "r") as f:
         yaml_output = yaml.load(f, Loader=get_loader())
     model_mapping = parse_yaml_output_to_mapping_dict(yaml_output)
     return model_mapping
 
 
-def read_mapping_from_yaml_string(yaml_code):
+def read_mapping_from_yaml_string(yaml_code: str) -> ModelMappingDict:
+    """This function reads a yaml string and returns a ModelMappingDict object.
+    Use the yaml tags !Int, !Float, !Cat to specify the type of the hyperparameter distributions.
+    The parser takes care of importing the classes specified in the yaml file in the fields model and post_processor.
+    
+    Args:
+        yaml_code (str): The yaml code.
+        
+    Returns:
+        (ModelMappingDict): A dictionary of ModelConfigDict objects.
+    
+    Example:
+
+        ```python
+        yaml_code = '''
+                    RandomForest:
+                        model: sklearn.ensemble.RandomForestRegressor
+                        post_processor: flexcv.model_postprocessing.MixedEffectsPostProcessor
+                        requires_inner_cv: True
+                        params:
+                            max_depth: !Int
+                                low: 1
+                                high: 10
+                    '''
+        model_mapping = read_mapping_from_yaml_string(yaml_code)
+        ```
+        
+    """
     yaml_output = yaml.load(yaml_code, Loader=get_loader())
     model_mapping = parse_yaml_output_to_mapping_dict(yaml_output)
     return model_mapping

--- a/test/test_yaml_parser.py
+++ b/test/test_yaml_parser.py
@@ -1,0 +1,155 @@
+import pytest
+import unittest.mock as mock
+from optuna.distributions import IntDistribution, CategoricalDistribution, FloatDistribution
+import yaml
+
+from flexcv.models import LinearModel
+from flexcv.model_postprocessing import LinearModelPostProcessor
+from flexcv.yaml_parser import read_mapping_from_yaml_string, read_mapping_from_yaml_file
+from flexcv.yaml_parser import parse_yaml_output_to_mapping_dict
+from flexcv.yaml_parser import get_loader
+from flexcv.model_mapping import ModelMappingDict, ModelConfigDict
+
+def test_parse_yaml_output_to_mapping_dict():
+    # Mock the importlib.import_module function
+    with mock.patch('importlib.import_module') as mock_import_module:
+        # Define a mock module with a mock class
+        mock_module = mock.Mock()
+        mock_class = mock.Mock()
+        setattr(mock_module, 'MockClass', mock_class)
+        mock_import_module.return_value = mock_module
+
+        # Define a sample yaml_dict
+        
+        yaml_dict = {
+            'MockModel': {
+                'model': 'mock_module.MockClass',
+                'post_processor': 'mock_module.MockClass',
+                'param1': 'value1',
+                'param2': 'value2',
+            }
+        }
+
+        # Call the function
+        result = parse_yaml_output_to_mapping_dict(yaml_dict)
+
+        # Check the result
+        assert isinstance(result, ModelMappingDict)
+        assert 'MockModel' in result
+        assert isinstance(result['MockModel'], ModelConfigDict)
+        assert result['MockModel']['model'] == mock_class
+        assert result['MockModel']['post_processor'] == mock_class
+        assert result['MockModel']['param1'] == 'value1'
+        assert result['MockModel']['param2'] == 'value2'
+
+def test_parse_yaml_output_to_mapping_dict_missing_model():
+    # Define a sample yaml_dict with missing 'model'
+    yaml_dict = {
+        'MockModel': {
+            'post_processor': 'mock_module.MockClass',
+            'param1': 'value1',
+            'param2': 'value2'
+        }
+    }
+
+    # Call the function and check for ValueError
+    with pytest.raises(ValueError) as excinfo:
+        parse_yaml_output_to_mapping_dict(yaml_dict)
+    assert str(excinfo.value) == 'model name is missing for model MockModel'
+
+def test_read_mapping_from_yaml_string():
+    # Mock the yaml.load and parse_yaml_output_to_mapping_dict functions
+    with mock.patch('yaml.load') as mock_load, \
+         mock.patch('flexcv.yaml_parser.parse_yaml_output_to_mapping_dict') as mock_parse:
+        # Define a mock yaml_output and mock model_mapping
+        mock_yaml_output = mock.Mock()
+        mock_model_mapping = mock.Mock()
+        mock_load.return_value = mock_yaml_output
+        mock_parse.return_value = mock_model_mapping
+
+        # Define a sample yaml_code
+        yaml_code = 'MockYamlCode'
+
+        # Call the function
+        result = read_mapping_from_yaml_string(yaml_code)
+
+        # Check the result
+        assert result == mock_model_mapping
+
+        # Check the calls to the mocked functions
+        mock_load.assert_called_once_with(yaml_code, Loader=get_loader())
+        mock_parse.assert_called_once_with(mock_yaml_output)
+
+def test_read_mapping_from_yaml_string_invalid_yaml():
+    # Mock the yaml.load function to raise a YAMLError
+    with mock.patch('yaml.load') as mock_load:
+        mock_load.side_effect = yaml.YAMLError
+
+        # Define a sample yaml_code
+        yaml_code = 'InvalidYamlCode'
+
+        # Call the function and check for YAMLError
+        with pytest.raises(yaml.YAMLError):
+            read_mapping_from_yaml_string(yaml_code)
+            
+def test_read_mapping_from_yaml_string_valid_yaml():
+    yaml_code = """
+    LinearModel:
+        model: flexcv.models.LinearModel
+        post_processor: flexcv.model_postprocessing.LinearModelPostProcessor
+        params:
+            max_depth: !Int
+                low: 5
+                high: 100
+                log: true
+            min_impurity_decrease: !Float
+                low: 0.00000001
+                high: 0.02
+            features: !Cat 
+                choices: [a, b, c]
+    """
+
+    python_result = read_mapping_from_yaml_string(yaml_code)
+    assert isinstance(python_result, ModelMappingDict)
+    assert 'LinearModel' in python_result
+    assert isinstance(python_result['LinearModel'], ModelConfigDict)
+    assert python_result['LinearModel']['model'] == LinearModel
+    assert python_result['LinearModel']['post_processor'] == LinearModelPostProcessor
+    assert python_result['LinearModel']['params']['max_depth'] == IntDistribution(low=5, high=100, log=True)
+    assert python_result['LinearModel']['params']['min_impurity_decrease'] == FloatDistribution(low=0.00000001, high=0.02)
+    assert python_result['LinearModel']['params']['features'] == CategoricalDistribution(choices=['a', 'b', 'c'])
+
+def test_read_mapping_from_yaml_file_valid_yaml():
+    yaml_code = """
+    LinearModel:
+        model: flexcv.models.LinearModel
+        post_processor: flexcv.model_postprocessing.LinearModelPostProcessor
+        params:
+            max_depth: !Int
+                low: 5
+                high: 100
+                log: true
+            min_impurity_decrease: !Float
+                low: 0.00000001
+                high: 0.02
+            features: !Cat 
+                choices: [a, b, c]
+    """
+    
+    # write it to a file
+    with open('test.yaml', 'w') as f:
+        f.write(yaml_code)
+    
+    python_result = read_mapping_from_yaml_file("test.yaml")
+    assert isinstance(python_result, ModelMappingDict)
+    assert 'LinearModel' in python_result
+    assert isinstance(python_result['LinearModel'], ModelConfigDict)
+    assert python_result['LinearModel']['model'] == LinearModel
+    assert python_result['LinearModel']['post_processor'] == LinearModelPostProcessor
+    assert python_result['LinearModel']['params']['max_depth'] == IntDistribution(low=5, high=100, log=True)
+    assert python_result['LinearModel']['params']['min_impurity_decrease'] == FloatDistribution(low=0.00000001, high=0.02)
+    assert python_result['LinearModel']['params']['features'] == CategoricalDistribution(choices=['a', 'b', 'c'])
+    # remove the file
+    import pathlib
+    pathlib.Path("test.yaml").unlink()
+    assert not pathlib.Path("test.yaml").exists()


### PR DESCRIPTION
Added two parsers for yaml strings and yaml files.
It is possible to define optuna distributions with the commands !Int !Float and !Cat.
The parser is integrated into CrossValidation.set_models().