### PR TITLE
add yaml parser to docs

### DIFF
--- a/docs/reference/yaml.md
+++ b/docs/reference/yaml.md
@@ -1,0 +1,5 @@
+# ::: flexcv.yaml_parser
+    options:
+        show_root_full_path: true
+        show_root_members_full_path: true
+        show_object_full_path: true

--- a/flexcv/yaml_parser.py
+++ b/flexcv/yaml_parser.py
@@ -135,7 +135,7 @@ def read_mapping_from_yaml_file(yaml_file_path: str) -> ModelMappingDict:
         The imports are done by the importlib module.
 
     Args:
-        yaml_code (str): The yaml code.
+        yaml_file_path (str): The yaml file path.
 
     Returns:
         (ModelMappingDict): A dictionary of ModelConfigDict objects.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,4 +96,5 @@ nav:
     - Plotting: reference/plotting.md
     - Utilities: reference/utilities.md
     - Data Synthesis: reference/synthesis.md
+    - YAML Parser: reference/yaml.md
   - About: about.md


### PR DESCRIPTION
The yaml_parser module is now part of the reference and a doc string in caml parser is fixed. It had .