### PR TITLE
fix #41 pin scipy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
   "neptune-xgboost >= 1.1.1",
   "neptune-sklearn >= 2.1.0",
   "pyyaml",
+  "scipy < 1.12",
 ]
 requires-python = ">=3.10,<3.12"
 


### PR DESCRIPTION
`neptune-sklearn` uses the `scikit-plot` package that is broken by `scipy==1.12`.
The problem is reported in https://github.com/reiinakano/scikit-plot/issues/119 and discussed in https://github.com/neptune-ai/neptune-sklearn/issues/24

Pinning scipy to <1.12 prevents scikit-plot to break during Import.